### PR TITLE
upgrade node v10 => v.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM amazonlinux
 
 # node + yarn
 RUN yum -y groupinstall 'Development Tools'
-RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl --silent --location https://rpm.nodesource.com/setup_14.x | bash -
 RUN curl --silent https://dl.yarnpkg.com/rpm/yarn.repo > /etc/yum.repos.d/yarn.repo
 RUN yum -y install nodejs yarn
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   region: ${env:REGION}
   stage: ${env:STAGE}
   timeout: 60


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/SRE-2299
Skusil som naivne node upgradnut rovno na v14 a vidim ze testy presli presli tak snad cajk
https://travis-ci.com/github/keboola/aws-cloudtrail-slack-hook/jobs/524148325
Pozeram ze tu napr boli updanute aj zavilsoti tak neviem ci sa mam do toho pustit podobne
https://github.com/keboola/aws-cloudwatch-logs-papertrail/pull/29/files
